### PR TITLE
Modernization and PEP8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,4 +10,6 @@ exclude =
     dist,
     # IDEs.
     .idea,
+    # CI environment.
+    deps,
 max-line-length = 140

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+ignore =
+exclude =
+    # Git.
+    .git,
+    # Python cache.
+    __pycache__,
+    # Build directories.
+    build,
+    dist,
+    # IDEs.
+    .idea,
+max-line-length = 140

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
         restore-keys:
           ccache-${{ matrix.os }}-${{ env.cc }}-${{ matrix.gamera }}-py${{ matrix.python }}
       if: ${{ matrix.gamera != 'master' }}
+    - name: update PIP
+      run:
+        python -m pip install --upgrade pip
     - name: download Gamera
       run: |
         url="https://github.com/hsnr-gamera/gamera-4/archive/${{ matrix.gamera }}.tar.gz"
@@ -127,13 +130,17 @@ jobs:
     - name: run tests
       run:
         make test
-    - name: determine coverage
-      run: |
+    - name: install coverage.py
+      run:
         python -m pip install coverage
+    - name: determine coverage
+      run:
         make update-coverage
-    - name: run flake8
-      run: |
+    - name: install flake8
+      run:
         python -m pip install flake8 pep8-naming
+    - name: run flake8
+      run:
         python -m flake8 .
     - name: check docs
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,10 @@ jobs:
       run: |
         python -m pip install coverage
         make update-coverage
-    # Does not work correctly with `py3exiv2` installed for now.
-    #- name: run pyflakes
-      #run: |
-        #python -m pip install pyflakes
-        #python -m pyflakes .
+    - name: run flake8
+      run: |
+        python -m pip install flake8 pep8-naming
+        python -m flake8 .
     - name: check docs
       run: |
         python -m pip install docutils pygments

--- a/didjvu
+++ b/didjvu
@@ -20,8 +20,9 @@ basedir = None
 if basedir is not None:
     sys.path[:0] = [basedir]
 
-from lib import didjvu
+# noinspection PyUnresolvedReferences
+from lib import didjvu  # noqa: E402
 
-didjvu.main()
+didjvu.Main()
 
 # vim:ts=4 sts=4 sw=4 et

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -13,80 +13,85 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''
+"""
 didjvu's command-line interface
-'''
+"""
 
 import argparse
 import functools
 
-from . import djvu_support as djvu
-from . import version
-from . import xmp
+from lib import djvu_support
+from lib import version
+from lib import xmp
+
 
 def range_int(x, y, typename):
-    class rint(int):
+    class RangeInt(int):
         def __new__(cls, n):
             n = int(n)
             if not (x <= n <= y):
                 raise ValueError
             return n
-    return type(typename, (rint,), {})
+    return type(typename, (RangeInt,), {})
 
-dpi_type = range_int(djvu.DPI_MIN, djvu.DPI_MAX, 'dpi')
-losslevel_type = range_int(djvu.LOSS_LEVEL_MIN, djvu.LOSS_LEVEL_MAX, 'loss level')
-subsample_type = range_int(djvu.SUBSAMPLE_MIN, djvu.SUBSAMPLE_MAX, 'subsample')
 
-def slice_type(max_slices=djvu.IW44_N_SLICES_MAX):
+DPI_TYPE = range_int(djvu_support.DPI_MIN, djvu_support.DPI_MAX, 'dpi')
+LOSS_LEVEL_TYPE = range_int(djvu_support.LOSS_LEVEL_MIN, djvu_support.LOSS_LEVEL_MAX, 'loss level')
+SUBSAMPLE_TYPE = range_int(djvu_support.SUBSAMPLE_MIN, djvu_support.SUBSAMPLE_MAX, 'subsample')
 
+
+def slice_type(max_slices=djvu_support.IW44_N_SLICES_MAX):
     def slices(value):
         result = []
         if ',' in value:
-            prev_slc = 0
-            for slc in value.split(','):
-                slc = int(slc)
-                if slc <= prev_slc:
+            previous_slice = 0
+            for slice_ in value.split(','):
+                slice_ = int(slice_)
+                if slice_ <= previous_slice:
                     raise ValueError('non-increasing slice value')
-                result += [slc]
-                prev_slc = slc
-            slc = 0
+                result += [slice_]
+                previous_slice = slice_
         elif '+' in value:
-            slc = 0
-            for slcinc in value.split('+'):
-                slcinc = int(slcinc)
-                if slcinc <= 0:
+            slice_ = 0
+            for slice_increase in value.split('+'):
+                slice_increase = int(slice_increase)
+                if slice_increase <= 0:
                     raise ValueError('non-increasing slice value')
-                slc += slcinc
-                result += [slc]
+                slice_ += slice_increase
+                result += [slice_]
         else:
-            slc = int(value)
-            if slc < 0:
+            slice_ = int(value)
+            if slice_ < 0:
                 raise ValueError('invalid slice value')
-            result = [slc]
+            result = [slice_]
         assert len(result) > 0
         if len(result) > max_slices:
             raise ValueError('too many slices')
         return result
     return slices
 
+
 def get_slice_repr(lst):
-    def fold(lst, obj):
-        return lst + [obj - sum(lst)]
-    plus_lst = functools.reduce(fold, lst[1:], lst[:1])
-    return '+'.join(map(str, plus_lst))
+    def fold(inner_list, obj):
+        return inner_list + [obj - sum(inner_list)]
 
-class intact(object):
+    plus_list = functools.reduce(fold, lst[1:], lst[:1])
+    return '+'.join(map(str, plus_list))
 
+
+class Intact:
     def __init__(self, x):
         self.x = x
 
     def __call__(self):
         return self.x
 
+
 def replace_underscores(s):
     return s.replace('_', '-')
 
-def _get_method_params_help(methods):
+
+def _get_method_parameters_help(methods):
     result = ['binarization methods and their parameters:']
     for name, method in sorted(methods.items()):
         result += ['  ' + name]
@@ -96,262 +101,262 @@ def _get_method_params_help(methods):
                 arg_help += '=' + 'NX'[arg.type is float]
                 arg_help_paren = []
                 if (arg.min is None) != (arg.max is None):
-                    message = 'inconsistent limits for {method}.{arg}: min={min}, max={max}'.format(
-                        method=name, arg=arg.name,
-                        min=arg.min, max=arg.max
-                    )
+                    message = f'inconsistent limits for {name}.{arg.name}: min={arg.min}, max={arg.max}'
                     raise NotImplementedError(message)
                 if arg.min is not None:
-                    arg_help_paren += ['{0} .. {1}'.format(arg.min, arg.max)]
+                    arg_help_paren += [f'{arg.min} .. {arg.max}']
                 if arg.default is not None:
-                    arg_help_paren += ['default: {0}'.format(arg.default)]
+                    arg_help_paren += [f'default: {arg.default}']
                 if arg_help_paren:
-                    arg_help += ' ({0})'.format(', '.join(arg_help_paren))
+                    arg_help += f' ({", ".join(arg_help_paren)})'
             elif arg.type is bool:
                 if arg.default is not False:
-                    message = 'unexpected default value for {method}.{arg}: {default}'.format(
-                        method=name, arg=arg.name,
-                        default=arg.default
-                    )
+                    message = f'unexpected default value for {name}.{arg.name}: {arg.default}'
                     raise NotImplementedError(message)
             else:
-                message = 'unexpected type for {method}.{arg}: {tp}'.format(method=name, arg=arg.name, tp=arg.type.__name__)
+                message = f'unexpected type for {name}.{arg.name}: {arg.type.__name__}'
                 raise NotImplementedError(message)
             result += ['  - ' + arg_help]
     return '\n'.join(result)
 
-class ArgumentParser(argparse.ArgumentParser):
 
-    class defaults(object):
+class ArgumentParser(argparse.ArgumentParser):
+    class Defaults:
         page_id_template = '{base-ext}.djvu'
         pages_per_dict = 1
         dpi = None
-        fg_slices = [100]
-        fg_crcb = djvu.CRCB.full
-        fg_subsample = 6
-        bg_slices = [74, 84, 90, 97]
-        bg_crcb = djvu.CRCB.normal
-        bg_subsample = 3
+        foreground_slices = [100]
+        foreground_crcb = djvu_support.CRCB.full
+        foreground_subsample = 6
+        background_slices = [74, 84, 90, 97]
+        background_crcb = djvu_support.CRCB.normal
+        background_subsample = 3
 
     def __init__(self, methods, default_method):
         super(ArgumentParser, self).__init__(formatter_class=argparse.RawDescriptionHelpFormatter)
         self.add_argument('--version', action=version.VersionAction)
-        p_separate = self.add_subparser('separate', help='generate masks for images')
-        p_encode = self.add_subparser('encode', help='convert images to single-page DjVu documents')
-        p_bundle = self.add_subparser('bundle', help='convert images to bundled multi-page DjVu document')
+        parser_separate = self.add_subparser('separate', help='generate masks for images')
+        parser_encode = self.add_subparser('encode', help='convert images to single-page DjVu documents')
+        parser_bundle = self.add_subparser('bundle', help='convert images to bundled multi-page DjVu document')
         epilog = []
-        default = self.defaults
-        for p in p_separate, p_encode, p_bundle:
-            epilog += ['{prog} --help'.format(prog=p.prog)]
-            p.add_argument('-o', '--output', metavar='FILE', help='output filename')
-            if p is p_bundle:
-                p.add_argument(
+        default = self.Defaults
+        for parser in (parser_separate, parser_encode, parser_bundle):
+            epilog += [f'{parser.prog} --help']
+            parser.add_argument('-o', '--output', metavar='FILE', help='output filename')
+
+            if parser is parser_bundle:
+                parser.add_argument(
                     '--page-id-template', metavar='TEMPLATE', default=default.page_id_template,
-                    help='naming scheme for page identifiers (default: "{template}")'.format(template=default.page_id_template)
+                    help=f'naming scheme for page identifiers (default: "{default.page_id_template}")'
                 )
-                p.add_argument(
-                    '--pageid-template', dest='page_id_template', metavar='TEMPLATE',
-                    help=argparse.SUPPRESS
-                )  # obsolete alias
             else:
-                p.add_argument(
+                parser.add_argument(
                     '--output-template', metavar='TEMPLATE',
-                    help='naming scheme for output file (e.g. "{template}")'.format(template=default.page_id_template)
+                    help=f'naming scheme for output file (e.g. "{default.page_id_template}")'
                 )
-            p.add_argument('--losslevel', dest='loss_level', type=losslevel_type, help=argparse.SUPPRESS)
-            p.add_argument(
-                '--loss-level', dest='loss_level', type=losslevel_type, metavar='N',
+
+            parser.add_argument('--losslevel', dest='loss_level', type=LOSS_LEVEL_TYPE, help=argparse.SUPPRESS)
+            parser.add_argument(
+                '--loss-level', dest='loss_level', type=LOSS_LEVEL_TYPE, metavar='N',
                 help='aggressiveness of lossy compression'
             )
-            p.add_argument(
-                '--lossless', dest='loss_level', action='store_const', const=djvu.LOSS_LEVEL_MIN,
+            parser.add_argument(
+                '--lossless', dest='loss_level', action='store_const', const=djvu_support.LOSS_LEVEL_MIN,
                 help='lossless compression (default)'
             )
-            p.add_argument(
-                '--clean', dest='loss_level', action='store_const', const=djvu.LOSS_LEVEL_CLEAN,
+            parser.add_argument(
+                '--clean', dest='loss_level', action='store_const', const=djvu_support.LOSS_LEVEL_CLEAN,
                 help='lossy compression: remove flyspecks'
             )
-            p.add_argument(
-                '--lossy', dest='loss_level', action='store_const', const=djvu.LOSS_LEVEL_LOSSY,
+            parser.add_argument(
+                '--lossy', dest='loss_level', action='store_const', const=djvu_support.LOSS_LEVEL_LOSSY,
                 help='lossy compression: substitute patterns with small variations'
             )
-            if p is not p_separate:
-                p.add_argument('--masks', nargs='+', metavar='MASK', help='use pre-generated masks')
-                p.add_argument('--mask', action='append', dest='masks', metavar='MASK', help='use a pre-generated mask')
-                for layer, layer_name in ('fg', 'foreground'), ('bg', 'background'):
-                    if layer == 'fg':
-                        def_slices = get_slice_repr(default.fg_slices)
-                        p.add_argument(
-                            '--fg-slices', type=slice_type(1), metavar='N',
-                            help='number of slices for foreground (default: {slices})'.format(slices=def_slices)
+
+            if parser is not parser_separate:
+                parser.add_argument('--masks', nargs='+', metavar='MASK', help='use pre-generated masks')
+                parser.add_argument('--mask', action='append', dest='masks', metavar='MASK', help='use a pre-generated mask')
+                for layer_name, layer_id in (('foreground', 'fg'), ('background', 'bg')):
+                    if layer_name == 'foreground':
+                        def_slices = get_slice_repr(default.foreground_slices)
+                        parser.add_argument(
+                            '--fg-slices', dest='foreground_slices', type=slice_type(1), metavar='N',
+                            help=f'number of slices for foreground (default: {def_slices})'
                         )
                     else:
-                        def_slices = get_slice_repr(default.bg_slices)
-                        p.add_argument(
-                            '--bg-slices', type=slice_type(), metavar='N+...+N',
-                            help='number of slices in each background chunk (default: {slices})'.format(slices=def_slices)
+                        def_slices = get_slice_repr(default.background_slices)
+                        parser.add_argument(
+                            '--bg-slices', dest='background_slices', type=slice_type(), metavar='N+...+N',
+                            help=f'number of slices in each background chunk (default: {def_slices})'
                         )
-                    default_crcb = getattr(default, '{lr}_crcb'.format(lr=layer))
-                    p.add_argument(
-                        '--{lr}-crcb'.format(lr=layer), choices=list(map(str, djvu.CRCB.values)),
-                        help='chrominance encoding for {layer} (default: {crcb})'.format(layer=layer_name, crcb=default_crcb)
+                    default_crcb = getattr(default, f'{layer_name}_crcb')
+                    parser.add_argument(
+                        f'--{layer_id}-crcb', dest=f'{layer_name}_crcb', choices=list(map(str, djvu_support.CRCB.values)),
+                        help=f'chrominance encoding for {layer_name} (default: {default_crcb})'
                     )
-                    default_subsample = getattr(default, '{lr}_subsample'.format(lr=layer))
-                    p.add_argument(
-                        '--{lr}-subsample'.format(lr=layer), type=subsample_type, metavar='N',
-                        help='subsample ratio for {layer} (default: {n})'.format(layer=layer_name, n=default_subsample)
+                    default_subsample = getattr(default, f'{layer_name}_subsample')
+                    parser.add_argument(
+                        f'--{layer_id}-subsample', dest=f'{layer_name}_subsample', type=SUBSAMPLE_TYPE, metavar='N',
+                        help=f'subsample ratio for {layer_name} (default: {default_subsample})'
                     )
-                p.add_argument('--fg-bg-defaults', help=argparse.SUPPRESS, action='store_const', const=1)
-            if p is not p_separate:
-                p.add_argument(
-                    '-d', '--dpi', type=dpi_type, metavar='N',
-                    help='image resolution (default: {dpi})'.format(dpi=djvu.DPI_DEFAULT)
+                parser.add_argument('--fg-bg-defaults', help=argparse.SUPPRESS, action='store_const', const=1)
+
+            if parser is not parser_separate:
+                parser.add_argument(
+                    '-d', '--dpi', type=DPI_TYPE, metavar='N',
+                    help=f'image resolution (default: {djvu_support.DPI_DEFAULT})'
                 )
-            if p is p_bundle:
-                p.add_argument(
+            if parser is parser_bundle:
+                parser.add_argument(
                     '-p', '--pages-per-dict', type=int, metavar='N',
-                    help='how many pages to compress in one pass (default: {n})'.format(n=default.pages_per_dict)
+                    help=f'how many pages to compress in one pass (default: {default.pages_per_dict})'
                 )
-            p.add_argument(
+            parser.add_argument(
                 '-m', '--method', choices=methods, metavar='METHOD', type=replace_underscores, default=default_method,
-                help='binarization method (default: {method})'.format(method=default_method)
+                help=f'binarization method (default: {default_method})'
             )
-            p.add_argument(
+            parser.add_argument(
                 '-x', '--param', action='append', dest='params', metavar='NAME[=VALUE]',
                 help='binarization method parameter (can be given more than once)'
             )
-            if p is p_encode or p is p_bundle:
-                p.add_argument('--xmp', action='store_true', help='create sidecar XMP metadata (experimental!)')
-            p.add_argument(
+            if parser is parser_encode or parser is parser_bundle:
+                parser.add_argument('--xmp', action='store_true', help='create sidecar XMP metadata (experimental!)')
+            parser.add_argument(
                 '-v', '--verbose', dest='verbosity', action='append_const', const=None,
                 help='more informational messages'
             )
-            p.add_argument(
+            parser.add_argument(
                 '-q', '--quiet', dest='verbosity', action='store_const', const=[],
                 help='no informational messages'
             )
-            p.add_argument('input', metavar='IMAGE', nargs='+')
-            p.set_defaults(
+            parser.add_argument('input', metavar='IMAGE', nargs='+')
+            parser.set_defaults(
                 masks=[],
                 fg_bg_defaults=None,
-                loss_level=djvu.LOSS_LEVEL_MIN,
+                loss_level=djvu_support.LOSS_LEVEL_MIN,
                 pages_per_dict=default.pages_per_dict,
                 dpi=default.dpi,
-                fg_slices=intact(default.fg_slices),
-                bg_slices=intact(default.bg_slices),
-                fg_crcb=intact(default.fg_crcb),
-                bg_crcb=intact(default.bg_crcb),
-                fg_subsample=intact(default.fg_subsample),
-                bg_subsample=intact(default.bg_subsample),
+                foreground_slices=Intact(default.foreground_slices),
+                background_slices=Intact(default.background_slices),
+                foreground_crcb=Intact(default.foreground_crcb),
+                background_crcb=Intact(default.background_crcb),
+                foreground_subsample=Intact(default.foreground_subsample),
+                background_subsample=Intact(default.background_subsample),
                 verbosity=[None],
                 xmp=False,
             )
-            p.epilog = _get_method_params_help(methods)
+            parser.epilog = _get_method_parameters_help(methods)
         self.epilog = 'more help:\n  ' + '\n  '.join(epilog)
         self.__methods = methods
 
     def add_subparser(self, name, **kwargs):
         try:
+            # noinspection PyUnresolvedReferences
             self.__subparsers
         except AttributeError:
             self.__subparsers = self.add_subparsers(parser_class=argparse.ArgumentParser)
-        kwargs.setdefault('formatter_class', argparse.RawDescriptionHelpFormatter)
-        p = self.__subparsers.add_parser(name, **kwargs)
-        p.set_defaults(_action_=name)
-        return p
 
-    def _parse_params(self, options):
-        o = options
-        result = {}
-        for param in o.params or ():
-            if '=' not in param:
-                if param.isdigit() and len(o.method.args) == 1:
-                    [pname] = o.method.args
-                    pvalue = param
+        kwargs.setdefault('formatter_class', argparse.RawDescriptionHelpFormatter)
+        parser = self.__subparsers.add_parser(name, **kwargs)
+        parser.set_defaults(_action_=name)
+        return parser
+
+    def _parse_parameters(self, options):
+        result = dict()
+        for parameter in options.params or ():
+            if '=' not in parameter:
+                if parameter.isdigit() and len(options.method.args) == 1:
+                    [parameter_name] = options.method.args
+                    parameter_value = parameter
                 else:
-                    pname = param
-                    pvalue = True
+                    parameter_name = parameter
+                    parameter_value = True
             else:
-                [pname, pvalue] = param.split('=', 1)
-            pname = replace_underscores(pname)
+                [parameter_name, parameter_value] = parameter.split('=', 1)
+            parameter_name = replace_underscores(parameter_name)
             try:
-                arg = o.method.args[pname]
+                argument = options.method.args[parameter_name]
             except KeyError:
-                self.error('invalid parameter name {0!r}'.format(pname))
+                self.error(f'invalid parameter name {parameter_name!r}')
             try:
-                if (pvalue is True) and (arg.type is not bool):
+                # noinspection PyUnboundLocalVariable
+                if (parameter_value is True) and (argument.type is not bool):
                     raise ValueError
-                pvalue = arg.type(pvalue)
+                parameter_value = argument.type(parameter_value)
             except ValueError:
-                self.error('invalid parameter {0} value: {1!r}'.format(pname, pvalue))
-            if (arg.min is not None) and pvalue < arg.min:
-                self.error('parameter {0} must be >= {1}'.format(pname, arg.min))
-            if (arg.max is not None) and pvalue > arg.max:
-                self.error('parameter {0} must be <= {1}'.format(pname, arg.max))
-            result[arg.name] = pvalue
-        for arg in o.method.args.values():
-            if (not arg.has_default) and (arg.name not in result):
-                self.error('parameter {0} is not set'.format(arg.name))
+                self.error(f'invalid parameter {parameter_name} value: {parameter_value!r}')
+            if (argument.min is not None) and parameter_value < argument.min:
+                self.error(f'parameter {parameter_name} must be >= {argument.min}')
+            if (argument.max is not None) and parameter_value > argument.max:
+                self.error(f'parameter {parameter_name} must be <= {argument.max}')
+            result[argument.name] = parameter_value
+        for argument in options.method.args.values():
+            if (not argument.has_default) and (argument.name not in result):
+                self.error(f'parameter {argument.name} is not set')
         return result
 
-    def parse_args(self, actions):
-        o = argparse.ArgumentParser.parse_args(self)
-        if not hasattr(o, 'fg_bg_defaults'):
+    # noinspection PyMethodOverriding
+    def parse_arguments(self, actions):
+        options = argparse.ArgumentParser.parse_args(self)
+        if not hasattr(options, 'fg_bg_defaults'):
             import sys
             self.print_usage()
             print('didjvu: error: too few arguments')
             sys.exit(2)
-        if o.fg_bg_defaults is None:
-            for layer in 'fg', 'bg':
+        if options.fg_bg_defaults is None:
+            for layer in 'foreground', 'background':
                 namespace = argparse.Namespace()
-                setattr(o, '{lr}_options'.format(lr=layer), namespace)
+                setattr(options, f'{layer}_options', namespace)
                 for facet in 'slices', 'crcb', 'subsample':
-                    attrname = '{lr}_{facet}'.format(lr=layer, facet=facet)
-                    value = getattr(o, attrname)
-                    if isinstance(value, intact):
+                    attribute_name = f'{layer}_{facet}'
+                    value = getattr(options, attribute_name)
+                    if isinstance(value, Intact):
                         value = value()
                     else:
-                        o.fg_bg_defaults = False
+                        options.fg_bg_defaults = False
                     setattr(namespace, facet, value)
-                    delattr(o, attrname)
+                    delattr(options, attribute_name)
                 if isinstance(namespace.crcb, str):
-                    namespace.crcb = getattr(djvu.CRCB, namespace.crcb)
-        if o.fg_bg_defaults is not False:
-            o.fg_bg_defaults = True
-        o.verbosity = len(o.verbosity)
-        if o.pages_per_dict <= 1:
-            o.pages_per_dict = 1
-        action = getattr(actions, vars(o).pop('_action_'))
-        o.method = self.__methods[o.method]
-        o.params = self._parse_params(o)
+                    namespace.crcb = getattr(djvu_support.CRCB, namespace.crcb)
+        if options.fg_bg_defaults is not False:
+            options.fg_bg_defaults = True
+        # noinspection PyTypeChecker
+        options.verbosity = len(options.verbosity)
+        if options.pages_per_dict <= 1:
+            options.pages_per_dict = 1
+        action = getattr(actions, vars(options).pop('_action_'))
+        options.method = self.__methods[options.method]
+        options.parameters = self._parse_parameters(options)
         try:
-            if o.xmp and not xmp.backend:
+            if options.xmp and not xmp.backend:
                 raise xmp.import_error  # pylint: disable=raising-bad-type
         except AttributeError:
             pass
-        return action(o)
+        return action(options)
 
-def dump_options(o, multipage=False):
-    method_name = o.method.name
-    if o.params:
+
+def dump_options(options, multi_page=False):
+    method_name = options.method.name
+    if options.params:
         method_name += ' '
         method_name += ' '.join(
-            '{0}={1}'.format(pname, pvalue)
-            for pname, pvalue
-            in sorted(o.params.items())
+            f'{parameter_name}={parameter_value}'
+            for parameter_name, parameter_value
+            in sorted(options.params.items())
         )
-    yield ('method', method_name)
-    if multipage:
-        yield ('pages-per-dict', o.pages_per_dict)
-    yield ('loss-level', o.loss_level)
-    if o.fg_bg_defaults:
-        yield ('fg-bg-defaults', True)
+    yield 'method', method_name
+    if multi_page:
+        yield 'pages-per-dict', options.pages_per_dict
+    yield 'loss-level', options.loss_level
+    if options.fg_bg_defaults:
+        yield 'fg-bg-defaults', True
     else:
         for layer_name in 'fg', 'bg':
-            layer = getattr(o, layer_name + '_options')
-            yield (layer_name + '-crcb', str(layer.crcb))
-            yield (layer_name + '-slices', get_slice_repr(layer.slices))
-            yield (layer_name + '-subsample', layer.subsample)
+            layer = getattr(options, f'{layer_name}_options')
+            yield f'{layer_name}-crcb', str(layer.crcb)
+            yield f'{layer_name}-slices', get_slice_repr(layer.slices)
+            yield f'{layer_name}-subsample', layer.subsample
+
 
 __all__ = ['ArgumentParser', 'dump_options']
 

--- a/lib/filetype.py
+++ b/lib/filetype.py
@@ -13,39 +13,43 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''
-filetype detection
-'''
+"""
+Filetype detection
+"""
 
-class generic(object):
 
-    def __new__(self, *args, **kwargs):
+class Generic:
+    def __new__(cls, *args, **kwargs):
         raise NotImplementedError  # no coverage
 
     @classmethod
     def like(cls, other):
         return issubclass(cls, other)
 
-class djvu(generic):
+
+class Djvu(Generic):
     pass
 
-class djvu_single(djvu):
+
+class DjvuSingle(Djvu):
     pass
+
 
 def check(filename):
-    cls = generic
+    cls = Generic
     with open(filename, 'rb') as file:
         header = file.read(16)
         if header.startswith(b'AT&TFORM'):
-            cls = djvu
+            cls = Djvu
             if header.endswith(b'DJVU'):
-                cls = djvu_single
+                cls = DjvuSingle
     return cls
+
 
 __all__ = [
     'check',
-    'djvu',
-    'djvu_single',
+    'Djvu',
+    'DjvuSingle',
 ]
 
 # vim:ts=4 sts=4 sw=4 et

--- a/lib/fs.py
+++ b/lib/fs.py
@@ -13,27 +13,29 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''filesystem functions'''
+"""
+Filesystem functions
+"""
 
 import os
 
-_block_size = 1 << 20  # 1 MiB
+_BLOCK_SIZE = 1 << 20  # 1 MiB
+
 
 def copy_file(input_file, output_file):
     length = 0
     while True:
-        block = input_file.read(_block_size)
+        block = input_file.read(_BLOCK_SIZE)
         if not block:
             break
         length += len(block)
         output_file.write(block)
     return length
 
+
 def replace_ext(filename, ext):
-    return '{0}.{1}'.format(
-        os.path.splitext(filename)[0],
-        ext
-    )
+    return f'{os.path.splitext(filename)[0]}.{ext}'
+
 
 __all__ = [
     'copy_file',

--- a/lib/templates.py
+++ b/lib/templates.py
@@ -13,23 +13,29 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''filename templates'''
+"""
+Filename templates
+"""
 
 import os
 import string
 
-formatter = string.Formatter()
+
+FORMATTER = string.Formatter()
+
 
 def expand(template, name, page, memo):
     base = os.path.basename(name)
     name_ext, _ = os.path.splitext(name)
     base_ext, _ = os.path.splitext(base)
     d = {
-        'name': name, 'name-ext': name_ext,
-        'base': base, 'base-ext': base_ext,
+        'name': name,
+        'name-ext': name_ext,
+        'base': base,
+        'base-ext': base_ext,
         'page': page + 1,
     }
-    for _, var, _, _ in formatter.parse(template):
+    for _, var, _, _ in FORMATTER.parse(template):
         if var is None:
             continue
         if '+' in var:
@@ -52,17 +58,18 @@ def expand(template, name, page, memo):
         if not isinstance(base_value, int):
             continue
         d[var] = d[base_var] + offset
-    ident = formatter.vformat(template, (), d)
+    ident = FORMATTER.vformat(template, (), d)
     while True:
         n = memo.get(ident, 0)
         if n == 0:
             break
         memo[ident] += 1
         ident_base, ident_ext = os.path.splitext(ident)
-        ident = '{base}.{n}{ext}'.format(base=ident_base, n=n, ext=ident_ext)
+        ident = f'{ident_base}.{n}{ident_ext}'
     assert ident not in memo
     memo[ident] = 1
     return ident
+
 
 __all__ = ['expand']
 

--- a/lib/temporary.py
+++ b/lib/temporary.py
@@ -13,7 +13,9 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''temporary files and directories'''
+"""
+Temporary files and directories
+"""
 
 import contextlib
 import functools
@@ -24,13 +26,17 @@ import tempfile
 file = functools.partial(tempfile.NamedTemporaryFile, prefix='didjvu.')
 name = functools.partial(tempfile.mktemp, prefix='didjvu.')
 
+
+# noinspection PyShadowingBuiltins
 def hardlink(path, suffix='', prefix='didjvu.', dir=None):
     new_path = name(suffix=suffix, prefix=prefix, dir=dir)
     os.link(path, new_path)
+    # noinspection PyUnresolvedReferences,PyProtectedMember
     return tempfile._TemporaryFileWrapper(
         open(new_path, 'r+b'),
         new_path
     )
+
 
 @contextlib.contextmanager
 def directory(*args, **kwargs):
@@ -41,6 +47,7 @@ def directory(*args, **kwargs):
         yield tmpdir
     finally:
         shutil.rmtree(tmpdir)
+
 
 __all__ = [
     'directory',

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -13,27 +13,31 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''various helper functions'''
+"""
+Various helper functions
+"""
 
 import os
 
-debian = os.path.exists('/etc/debian_version')
+IS_DEBIAN = os.path.exists('/etc/debian_version')
+
 
 def enhance_import_error(exception, package, debian_package, homepage):
-    has_debian_package = bool(debian and debian_package)
+    has_debian_package = bool(IS_DEBIAN and debian_package)
     message = str(exception)
     if has_debian_package:
         package = debian_package
-    message += '; please install the {pkg} package'.format(pkg=package)
+    message += f'; please install the {package} package'
     if not has_debian_package:
-        message += ' <{url}>'.format(url=homepage)
+        message += f' <{homepage}>'
     exception.msg = message
 
-class namespace(object):
+
+class Namespace:
     pass
 
-class Proxy(object):
 
+class Proxy:
     def __init__(self, obj, wait_fn, temporaries):
         self._object = obj
         self._wait_fn = wait_fn
@@ -53,10 +57,11 @@ class Proxy(object):
         self._wait_fn = int
         return setattr(self._object, name, value)
 
+
 __all__ = [
+    'Namespace',
     'Proxy',
     'enhance_import_error',
-    'namespace',
 ]
 
 # vim:ts=4 sts=4 sw=4 et

--- a/lib/version.py
+++ b/lib/version.py
@@ -13,27 +13,27 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''
+"""
 didjvu version information
-'''
-
-
+"""
 
 import argparse
 import sys
 
 __version__ = '0.9.1'
 
+
 def get_software_agent():
     import gamera
-    result = 'didjvu ' + __version__
-    result += ' (Gamera {0})'.format(gamera.__version__)
+    result = f'didjvu {__version__}'
+    result += f' (Gamera {gamera.__version__})'
     return result
 
+
 class VersionAction(argparse.Action):
-    '''
+    """
     argparse --version action
-    '''
+    """
 
     def __init__(self, option_strings, dest=argparse.SUPPRESS):
         super(VersionAction, self).__init__(
@@ -44,21 +44,27 @@ class VersionAction(argparse.Action):
         )
 
     def __call__(self, parser, namespace, values, option_string=None):
-        print('{prog} {0}'.format(__version__, prog=parser.prog))
-        print('+ Python {0}.{1}.{2}'.format(*sys.version_info))
-        from . import gamera_support as gs
-        print('+ Gamera {0}'.format(gs.gamera.__version__))
+        print(f'{parser.prog} {__version__}')
+        python_version = sys.version_info
+        print(f'+ Python {python_version.major}.{python_version.minor}.{python_version.micro}')
+
+        from lib import gamera_support
+        print(f'+ Gamera {gamera_support.gamera.__version__}')
         pil_name = 'Pillow'
         try:
-            pil_version = gs.PIL.PILLOW_VERSION
+            # noinspection PyUnresolvedReferences
+            pil_version = gamera_support.PILImage.PILLOW_VERSION
         except AttributeError:
             try:
-                pil_version = gs.PIL.__version__
+                # noinspection PyUnresolvedReferences
+                pil_version = gamera_support.PILImage.__version__
             except AttributeError:
                 pil_name = 'PIL'
-                pil_version = gs.PIL.VERSION
-        print('+ {PIL} {0}'.format(pil_version, PIL=pil_name))
+                # noinspection PyUnresolvedReferences
+                pil_version = gamera_support.PILImage.VERSION
+        print(f'+ {pil_name} {pil_version}')
         parser.exit()
+
 
 __all__ = [
     'VersionAction',

--- a/lib/xmp/libxmp_backend.py
+++ b/lib/xmp/libxmp_backend.py
@@ -13,29 +13,32 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''XMP support (python-xmp-toolkit backend)'''
+"""
+XMP support (python-xmp-toolkit backend)
+"""
 
 import libxmp
 
-from .. import timestamp
+from lib import timestamp
 
-from . import namespaces as ns
+from lib.xmp import namespaces
+
 
 class XmpError(RuntimeError):
     pass
 
-class MetadataBase(object):
 
+class MetadataBase:
     def __init__(self):
         backend = self._backend = libxmp.XMPMeta()
-        prefix = backend.register_namespace(ns.didjvu, 'didjvu')
+        prefix = backend.register_namespace(namespaces.didjvu, 'didjvu')
         if prefix is None:
             raise XmpError('Cannot register namespace for didjvu internal properties')  # no coverage
 
     @classmethod
     def _expand_key(cls, key):
         namespace, key = key.split('.', 1)
-        namespace = getattr(ns, namespace.lower())
+        namespace = getattr(namespaces, namespace.lower())
         return namespace, key
 
     def get(self, key, fallback=None):
@@ -59,47 +62,51 @@ class MetadataBase(object):
         namespace, key = self._expand_key(key)
         backend = self._backend
         if isinstance(value, bool):
-            rc = backend.set_property_bool(namespace, key, value)
+            return_code = backend.set_property_bool(namespace, key, value)
         elif isinstance(value, int):
-            rc = backend.set_property_int(namespace, key, value)
+            return_code = backend.set_property_int(namespace, key, value)
         elif isinstance(value, list) and len(value) == 0:
-            rc = backend.set_property(namespace, key, '',
+            return_code = backend.set_property(
+                namespace, key, '',
                 prop_value_is_array=True,
                 prop_array_is_ordered=True
             )
         else:
             if isinstance(value, timestamp.Timestamp):
                 value = str(value)
-            rc = backend.set_property(namespace, key, value)
-        if rc is False:
+            return_code = backend.set_property(namespace, key, value)
+        if return_code is False:
             raise XmpError('Cannot set property')  # no coverage
 
     def _add_to_history(self, event, index):
         for key, value in event.items:
             if value is None:
                 continue
-            self['xmpMM.History[{i}]/stEvt:{key}'.format(i=index, key=key)] = value
+            self[f'xmpMM.History[{index}]/stEvt:{key}'] = value
 
     def append_to_history(self, event):
         backend = self._backend
+
         def count_history():
-            return backend.count_array_items(ns.xmpmm, 'History')
+            return backend.count_array_items(namespaces.xmpmm, 'History')
+
         count = count_history()
         if count == 0:
             self['xmpMM.History'] = []
             assert count_history() == 0
-        result = self._add_to_history(event, count + 1)
+
+        self._add_to_history(event, count + 1)
         assert count_history() == count + 1
-        return result
 
     def serialize(self):
         backend = self._backend
         return backend.serialize_and_format(omit_packet_wrapper=True, tabchr='    ')
 
-    def read(self, file):
+    def read(self, fp):
         backend = self._backend
-        xmp = file.read()
+        xmp = fp.read()
         backend.parse_from_str(xmp)
+
 
 __all__ = ['MetadataBase']
 

--- a/lib/xmp/namespaces.py
+++ b/lib/xmp/namespaces.py
@@ -13,9 +13,9 @@
 # FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 # for more details.
 
-'''
-constants for various XML namespaces
-'''
+"""
+Constants for various XML namespaces
+"""
 
 didjvu = 'http://jwilk.net/software/didjvu#'
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,7 +126,7 @@ class SliceRepresentationTestCase(TestCase):
 class IntactTestCase(TestCase):
     def test_intact(self):
         x = object()
-        intact_x = cli.intact(x)
+        intact_x = cli.Intact(x)
         self.assertIs(intact_x(), x)
 
 
@@ -172,7 +172,7 @@ class ArgumentParserTestCase(TestCase):
                 contextlib.redirect_stdout(stdout):
             parser = cli.ArgumentParser(self.methods, 'djvu')
             with self.assertRaises(expected_exception=SystemExit) as exception_manager:
-                parser.parse_args(dict())
+                parser.parse_arguments(dict())
             self.assertEqual(exception_manager.exception.args, (2,))
 
         actions = ','.join(self.action_names)
@@ -190,7 +190,7 @@ class ArgumentParserTestCase(TestCase):
                 contextlib.redirect_stderr(stderr):
             parser = cli.ArgumentParser(self.methods, 'djvu')
             with self.assertRaises(expected_exception=SystemExit) as exception_manager:
-                parser.parse_args(dict())
+                parser.parse_arguments(dict())
             self.assertEqual(exception_manager.exception.args, (2,))
         self.assertRegex(
             stderr.getvalue(),
@@ -215,7 +215,7 @@ class ArgumentParserTestCase(TestCase):
                 contextlib.redirect_stderr(stderr):
             parser = cli.ArgumentParser(self.methods, 'djvu')
             with self.assertRaises(expected_exception=SystemExit) as exception_manager:
-                parser.parse_args(dict())
+                parser.parse_arguments(dict())
             self.assertEqual(exception_manager.exception.args, (2,))
         action_values = ','.join(self.action_names)
         action_strings = ', '.join(map(repr, self.action_names))
@@ -242,7 +242,7 @@ class ArgumentParserTestCase(TestCase):
         argv += args
         with mock.patch('sys.argv', argv), contextlib.redirect_stderr(stderr):
             parser = cli.ArgumentParser(self.methods, 'djvu')
-            selected_action, options = parser.parse_args(self.actions)
+            selected_action, options = parser.parse_arguments(self.actions)
         self.assertMultiLineEqual(stderr.getvalue(), '')
         self.assertEqual(selected_action, action)
         return options
@@ -262,7 +262,7 @@ class ArgumentParserTestCase(TestCase):
         self.assertEqual(options.loss_level, 0)
         self.assertEqual(options.pages_per_dict, 1)
         self.assertIs(options.method, self.methods['djvu'])
-        self.assertEqual(options.params, {})
+        self.assertEqual(options.parameters, {})
         self.assertEqual(options.verbosity, 1)
         self.assertIs(options.xmp, False)
 
@@ -280,7 +280,7 @@ class ArgumentParserTestCase(TestCase):
         with mock.patch('sys.argv', argv), contextlib.redirect_stdout(stdout):
             parser = cli.ArgumentParser(self.methods, 'djvu')
             with self.assertRaises(expected_exception=SystemExit) as exception_manager:
-                parser.parse_args(dict())
+                parser.parse_arguments(dict())
             self.assertEqual(exception_manager.exception.args, (0,))
         self.assertGreater(len(stdout.getvalue()), 0)
 

--- a/tests/test_filetype.py
+++ b/tests/test_filetype.py
@@ -24,13 +24,13 @@ class FileTypeTestCase(TestCase):
     def test_djvu(self):
         path = self.get_data_file('ycbcr.djvu')
         file_type = filetype.check(path)
-        self.assertTrue(file_type.like(filetype.djvu))
-        self.assertTrue(file_type.like(filetype.djvu_single))
+        self.assertTrue(file_type.like(filetype.Djvu))
+        self.assertTrue(file_type.like(filetype.DjvuSingle))
 
     def test_bad(self):
         path = self.get_data_file(os.devnull)
         file_type = filetype.check(path)
-        self.assertFalse(file_type.like(filetype.djvu))
-        self.assertFalse(file_type.like(filetype.djvu_single))
+        self.assertFalse(file_type.like(filetype.Djvu))
+        self.assertFalse(file_type.like(filetype.DjvuSingle))
 
 # vim:ts=4 sts=4 sw=4 et

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -37,7 +37,7 @@ class CopyFileTestCase(TestCase):
 
         data = 'eggs' + 'spam' * 42
         with self.subTest(data=data):
-            with mock.patch.object(fs, '_block_size', 1):
+            with mock.patch.object(fs, '_BLOCK_SIZE', 1):
                 self._test_copy_file(data)
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -30,7 +30,7 @@ class TemplatesTestCase(TestCase):
         self.assertEqual(result, '/path/to/eggs.djvu')
         result = templates.expand('{base-ext}.djvu', path, 0, memo)
         self.assertEqual(result, 'eggs.djvu')
-    
+
     def test_page(self):
         path = '/path/to/eggs.png'
         memo = {}
@@ -44,25 +44,25 @@ class TemplatesTestCase(TestCase):
         self.assertEqual(result, '69')
         result = templates.expand('{page-26}', path, 42, memo)
         self.assertEqual(result, '17')
-    
+
     def test_bad_offset(self):
         path = '/path/to/eggs.png'
         with self.assertRaises(expected_exception=KeyError) as exception_manager:
             templates.expand('{page+ham}', path, 42, {})
         self.assertEqual(exception_manager.exception.args, ('page+ham',))
-    
+
     def test_bad_type_offset(self):
         path = '/path/to/eggs.png'
         with self.assertRaises(expected_exception=KeyError) as exception_manager:
             templates.expand('{base-37}', path, 42, {})
         self.assertEqual(exception_manager.exception.args, ('base-37',))
-    
+
     def test_bad_var_offset(self):
         path = '/path/to/eggs.png'
         with self.assertRaises(expected_exception=KeyError) as exception_manager:
             templates.expand('{eggs-37}', path, 42, {})
         self.assertEqual(exception_manager.exception.args, ('eggs-37',))
-    
+
     def test_multi_offset(self):
         path = '/path/to/eggs.png'
         with self.assertRaises(expected_exception=KeyError) as exception_manager:
@@ -71,7 +71,7 @@ class TemplatesTestCase(TestCase):
         with self.assertRaises(expected_exception=KeyError) as exception_manager:
             templates.expand('{eggs-bacon-ham}', path, 42, {})
         self.assertEqual(exception_manager.exception.args, ('eggs-bacon-ham',))
-    
+
     def test_duplicates(self):
         path = '/path/to/eggs.png'
         memo = {}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,7 +28,7 @@ class EnhanceImportTestCase(TestCase):
         sys.modules['nonexistent'] = None
 
     def test_debian(self):
-        with mock.patch.object(utils, 'debian', True):
+        with mock.patch.object(utils, 'IS_DEBIAN', True):
             with self.assertRaises(expected_exception=ImportError) as exception_manager:
                 try:
                     # noinspection PyUnresolvedReferences
@@ -51,7 +51,7 @@ class EnhanceImportTestCase(TestCase):
             )
 
     def test_debian_without_debian_package_name(self):
-        with mock.patch.object(utils, 'debian', True):
+        with mock.patch.object(utils, 'IS_DEBIAN', True):
             with self.assertRaises(expected_exception=ImportError) as exception_manager:
                 try:
                     # noinspection PyUnresolvedReferences
@@ -74,7 +74,7 @@ class EnhanceImportTestCase(TestCase):
             )
 
     def test_non_debian(self):
-        with mock.patch.object(utils, 'debian', False):
+        with mock.patch.object(utils, 'IS_DEBIAN', False):
             with self.assertRaises(expected_exception=ImportError) as exception_manager:
                 try:
                     # noinspection PyUnresolvedReferences

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -132,7 +132,7 @@ class MetadataTestCase(UuuidCheckMixin, TestCase):
             with temporary.file(mode='w+t') as xmp_file:
                 exception = None
                 try:
-                    meta = xmp.metadata(backend=backend)
+                    meta = xmp.metadata(backend_module=backend)
                     meta.write(xmp_file)
                     xmp_file.flush()
                     xmp_file.seek(0)
@@ -196,7 +196,7 @@ class MetadataTestCase(UuuidCheckMixin, TestCase):
             with temporary.file(mode='w+t') as xmp_file:
                 exception = None
                 try:
-                    meta = xmp.metadata(backend=backend)
+                    meta = xmp.metadata(backend_module=backend)
                     meta.update(
                         media_type='image/x-test',
                         internal_properties=[
@@ -307,7 +307,7 @@ class MetadataTestCase(UuuidCheckMixin, TestCase):
             with temporary.file(mode='w+t') as xmp_file:
                 exception = None
                 try:
-                    meta = xmp.metadata(backend=backend)
+                    meta = xmp.metadata(backend_module=backend)
                     meta.import_(image_path)
                     meta.update(
                         media_type='image/x-test',
@@ -460,13 +460,13 @@ class MetadataTestCase(UuuidCheckMixin, TestCase):
 
     def _test_io_error(self, backend):
         image_path = self.get_data_file('nonexistent.png')
-        meta = xmp.metadata(backend=backend)
+        meta = xmp.metadata(backend_module=backend)
         meta.import_(image_path)
         with temporary.directory() as tmpdir:
             os.chmod(tmpdir, 0o000)
             try:
                 image_path = os.path.join(tmpdir, 'example.png')
-                meta = xmp.metadata(backend=backend)
+                meta = xmp.metadata(backend_module=backend)
                 with self.assertRaises(expected_exception=IOError):
                     meta.import_(image_path)
             finally:


### PR DESCRIPTION
* Modernize the code by removing the now redundant `object` as the base class.
* Use f-strings where possible.
* Fix issues detected by *flake8* regarding PEP8 styling.
* Use absolute instead of relative imports.