### PR TITLE
Resolve ResourceWarnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         rm -rf deps
     - name: check Boost.Python
       run:
-        ls -l /usr/local/lib/libbost*
+        ls -l /usr/local/lib/libboost*
     - name: update LD_LIBRARY_PATH
       run:
         echo "LD_LIBRARY_PATH=/usr/local/lib:$( echo $LD_LIBRARY_PATH )" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     - name: unpack Gamera
       run: |
         cd deps/
-        tar -xvzf gamera-*.tar.gz
+        tar -xzf gamera-*.tar.gz
     - name: build Gamera
       run: |
         cd deps/gamera-*/
@@ -133,10 +133,11 @@ jobs:
         mkdir deps
         wget $BOOST_URL -O deps/boost.tar.gz
         cd deps
-        tar -xvzf boost.tar.gz
+        tar -xzf boost.tar.gz
         cd boost_*/
-        ./bootstrap.sh --with-libraries=python
+        ./bootstrap.sh --with-libraries=python --with-python=python
         sudo ./b2 install
+        rm -rf deps
     - name: install py3exiv2
       run: |
         sudo apt-get install libexiv2-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,12 @@ jobs:
         cd deps
         tar -xzf boost.tar.gz
         cd boost_*/
-        ./bootstrap.sh --with-libraries=python --with-python=python
+        ./bootstrap.sh --with-libraries=python
         sudo ./b2 install
         rm -rf deps
+    - name: check Boost.Python
+      run:
+        locate libboost_python
     - name: install py3exiv2
       run: |
         sudo apt-get install libexiv2-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,6 @@ jobs:
         cd boost_*/
         ./bootstrap.sh --with-libraries=python
         sudo ./b2 install
-        rm -rf deps
     - name: install py3exiv2
       run: |
         sudo apt-get install libexiv2-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,10 @@ jobs:
         rm -rf deps
     - name: check Boost.Python
       run:
-        locate libboost_python
+        ls -l /usr/local/lib/libbost*
+    - name: update LD_LIBRARY_PATH
+      run:
+        echo "LD_LIBRARY_PATH=/usr/local/lib:$( echo $LD_LIBRARY_PATH )" >> $GITHUB_ENV
     - name: install py3exiv2
       run: |
         sudo apt-get install libexiv2-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,13 @@ jobs:
         ./bootstrap.sh --with-libraries=python
         sudo ./b2 install
         rm -rf deps
+    # The following two steps ensure that `libboost_python*.so.*` actually is available.
+    # Otherwise, the shared object would not be found during the tests (although the
+    # *py3exiv2* build actually finds them beforehand). For this reason, just add
+    # the installation path to the search path for Python.
+    # The alternative would be to use `--prefix` during bootstrapping above with the
+    # original value of `LD_LIBRARY_PATH`.
+    # Reference: https://github.com/boostorg/boost/blob/master/bootstrap.sh
     - name: check Boost.Python
       run:
         ls -l /usr/local/lib/libboost*

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -66,10 +66,10 @@ class WaitTestCase(TestCase):
 
     def _test_signal(self, name):
         # Any long-standing process would do.
-        child = ipc.Subprocess(['cat'], stdin=ipc.PIPE)
-        os.kill(child.pid, getattr(signal, name))
         with self.assertRaises(expected_exception=ipc.CalledProcessInterrupted) as exception_manager:
-            child.wait()
+            with ipc.Subprocess(['cat'], stdin=ipc.PIPE) as child:
+                os.kill(child.pid, getattr(signal, name))
+        
         self.assertEqual(
             str(exception_manager.exception),
             f"Command 'cat' was interrupted by signal {name}"

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -69,7 +69,7 @@ class WaitTestCase(TestCase):
         with self.assertRaises(expected_exception=ipc.CalledProcessInterrupted) as exception_manager:
             with ipc.Subprocess(['cat'], stdin=ipc.PIPE) as child:
                 os.kill(child.pid, getattr(signal, name))
-        
+
         self.assertEqual(
             str(exception_manager.exception),
             f"Command 'cat' was interrupted by signal {name}"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -37,12 +37,15 @@ class ChangelogTestCase(TestCase):
 class ManpageTestCase(TestCase):
     def test_manpage(self):
         path = os.path.join(DOC_DIRECTORY, 'manpage.xml')
-        for event, element in ElementTree.iterparse(path):
-            if element.tag == 'refmiscinfo' and element.get('class') == 'version':
-                self.assertEqual(element.text, version.__version__)
-                break
-        else:
-            self.fail("missing <refmiscinfo class='version'>")
+        # Do not feed path into `iterparse()` due to
+        # https://github.com/python/cpython/issues/69893
+        with open(path, mode='rb') as fd:
+            for event, element in ElementTree.iterparse(fd):
+                if element.tag == 'refmiscinfo' and element.get('class') == 'version':
+                    self.assertEqual(element.text, version.__version__)
+                    break
+            else:
+                self.fail("missing <refmiscinfo class='version'>")
 
 
 class GetSoftwareAgentTestCase(TestCase):

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -17,6 +17,7 @@ import importlib
 import io
 import logging
 import os
+from contextlib import contextmanager
 from xml.etree import ElementTree
 
 from tests.tools import SkipTest, TestCase
@@ -101,25 +102,29 @@ class NamespacesTestCase(TestCase):
 
 
 class MetadataTestCase(UuuidCheckMixin, TestCase):
+    @contextmanager
     def run_exiv2(self, filename, fail_ok=False):
+        def read_from_subprocess():
+            try:
+                with ipc.Subprocess(
+                        ['exiv2', '-P', 'Xkt', 'print', filename],
+                        stdout=ipc.PIPE,
+                        stderr=ipc.PIPE,
+                ) as child:
+                    for line in sorted(child.stdout):
+                        yield line.decode('utf-8')
+                    stderr = child.stderr.read()
+                    if not fail_ok:
+                        self.assertEqual(stderr.decode('utf-8'), '')
+            except OSError as exception:
+                raise self.SkipTest(str(exception))
+
         try:
-            child = ipc.Subprocess(
-                ['exiv2', '-P', 'Xkt', 'print', filename],
-                stdout=ipc.PIPE,
-                stderr=ipc.PIPE,
-            )
-        except OSError as exception:
-            raise self.SkipTest(str(exception))
-        for line in sorted(child.stdout):
-            yield line.decode('utf-8')
-        stderr = child.stderr.read()
-        if not fail_ok:
-            self.assertEqual(stderr.decode('utf-8'), '')
-        try:
-            child.wait()
+            yield read_from_subprocess()
         except ipc.CalledProcessError:
             if not fail_ok:
                 raise
+        
 
     def assert_correct_software_agent(self, software_agent):
         self.assertRegex(
@@ -151,8 +156,9 @@ class MetadataTestCase(UuuidCheckMixin, TestCase):
     def _test_empty_exiv2(self, xmp_file, exception=None):
         if exception is not None:
             raise exception
-        for line in self.run_exiv2(xmp_file.name, fail_ok=True):
-            self.assertEqual(line, '')
+        with self.run_exiv2(xmp_file.name, fail_ok=True) as output:
+            for line in output:
+                self.assertEqual(line, '')
 
     def _test_empty_libxmp(self, xmp_file, exception=None):
         if exception is not None:
@@ -223,54 +229,54 @@ class MetadataTestCase(UuuidCheckMixin, TestCase):
     def _test_new_exiv2(self, xmp_file, exception=None):
         if exception is not None:
             raise exception
-        output = self.run_exiv2(xmp_file.name)
 
-        def pop():
-            return tuple(next(output).rstrip('\n').split(None, 1))
+        with self.run_exiv2(xmp_file.name) as output:
+            def pop():
+                return tuple(next(output).rstrip('\n').split(None, 1))
 
-        # Dublin Core:
-        self.assertEqual(pop(), ('Xmp.dc.format', 'image/x-test'))
-        # Internal properties:
-        self.assertEqual(pop(), ('Xmp.didjvu.test_bool', 'True'))
-        self.assertEqual(pop(), ('Xmp.didjvu.test_int', '42'))
-        self.assertEqual(pop(), ('Xmp.didjvu.test_str', 'eggs'))
-        # XMP:
-        key, metadata_date = pop()
-        self.assert_rfc3339_timestamp(metadata_date)
-        self.assertEqual(key, 'Xmp.xmp.MetadataDate')
-        key, modify_date = pop()
-        self.assertEqual(key, 'Xmp.xmp.ModifyDate')
-        self.assert_rfc3339_timestamp(modify_date)
-        self.assertEqual(metadata_date, modify_date)
-        # XMP Media Management:
-        # - DocumentID:
-        key, document_id = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.DocumentID')
-        self.assert_uuid_urn(document_id)
-        # - History:
-        self.assertEqual(pop(), ('Xmp.xmpMM.History', 'type="Seq"'))
-        # - History[1]:
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[1]', 'type="Struct"'))
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:action', 'converted'))
-        key, event_instance_id = pop()
-        self.assert_uuid_urn(event_instance_id)
-        self.assertEqual(key, 'Xmp.xmpMM.History[1]/stEvt:instanceID')
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:parameters', 'to image/x-test'))
-        key, software_agent = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.History[1]/stEvt:softwareAgent')
-        self.assert_correct_software_agent(software_agent)
-        key, event_date = pop()
-        self.assertEqual((key, event_date), ('Xmp.xmpMM.History[1]/stEvt:when', modify_date))
-        # - InstanceID:
-        key, instance_id = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.InstanceID')
-        self.assert_uuid_urn(instance_id)
-        self.assertEqual(instance_id, event_instance_id)
-        try:
-            line = pop()
-        except StopIteration:
-            line = None
-        self.assertIsNone(line)
+            # Dublin Core:
+            self.assertEqual(pop(), ('Xmp.dc.format', 'image/x-test'))
+            # Internal properties:
+            self.assertEqual(pop(), ('Xmp.didjvu.test_bool', 'True'))
+            self.assertEqual(pop(), ('Xmp.didjvu.test_int', '42'))
+            self.assertEqual(pop(), ('Xmp.didjvu.test_str', 'eggs'))
+            # XMP:
+            key, metadata_date = pop()
+            self.assert_rfc3339_timestamp(metadata_date)
+            self.assertEqual(key, 'Xmp.xmp.MetadataDate')
+            key, modify_date = pop()
+            self.assertEqual(key, 'Xmp.xmp.ModifyDate')
+            self.assert_rfc3339_timestamp(modify_date)
+            self.assertEqual(metadata_date, modify_date)
+            # XMP Media Management:
+            # - DocumentID:
+            key, document_id = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.DocumentID')
+            self.assert_uuid_urn(document_id)
+            # - History:
+            self.assertEqual(pop(), ('Xmp.xmpMM.History', 'type="Seq"'))
+            # - History[1]:
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[1]', 'type="Struct"'))
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:action', 'converted'))
+            key, event_instance_id = pop()
+            self.assert_uuid_urn(event_instance_id)
+            self.assertEqual(key, 'Xmp.xmpMM.History[1]/stEvt:instanceID')
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:parameters', 'to image/x-test'))
+            key, software_agent = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.History[1]/stEvt:softwareAgent')
+            self.assert_correct_software_agent(software_agent)
+            key, event_date = pop()
+            self.assertEqual((key, event_date), ('Xmp.xmpMM.History[1]/stEvt:when', modify_date))
+            # - InstanceID:
+            key, instance_id = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.InstanceID')
+            self.assert_uuid_urn(instance_id)
+            self.assertEqual(instance_id, event_instance_id)
+            try:
+                line = pop()
+            except StopIteration:
+                line = None
+            self.assertIsNone(line)
 
     def _test_new_libxmp(self, xmp_file, exception=None):
         if exception is not None:
@@ -340,73 +346,73 @@ class MetadataTestCase(UuuidCheckMixin, TestCase):
     def _test_updated_exiv2(self, xmp_file, exception=None):
         if exception is not None:
             raise exception
-        output = self.run_exiv2(xmp_file.name)
 
-        def pop():
-            return tuple(next(output).rstrip('\n').split(None, 1))
+        with self.run_exiv2(xmp_file.name) as output:
+            def pop():
+                return tuple(next(output).rstrip('\n').split(None, 1))
 
-        # Dublin Core:
-        self.assertEqual(pop(), ('Xmp.dc.format', 'image/x-test'))
-        # Internal properties:
-        self.assertEqual(pop(), ('Xmp.didjvu.test_bool', 'True'))
-        self.assertEqual(pop(), ('Xmp.didjvu.test_int', '42'))
-        self.assertEqual(pop(), ('Xmp.didjvu.test_str', 'eggs'))
-        # TIFF:
-        self.assertEqual(pop(), ('Xmp.tiff.ImageHeight', '42'))
-        self.assertEqual(pop(), ('Xmp.tiff.ImageWidth', '69'))
-        # XMP:
-        key, create_date = pop()
-        self.assertEqual((key, create_date), ('Xmp.xmp.CreateDate', self._original_create_date))
-        self.assertEqual(pop(), ('Xmp.xmp.CreatorTool', self._original_software_agent))
-        key, metadata_date = pop()
-        self.assertEqual(key, 'Xmp.xmp.MetadataDate')
-        self.assert_rfc3339_timestamp(metadata_date)
-        key, modify_date = pop()
-        self.assertEqual(key, 'Xmp.xmp.ModifyDate')
-        self.assert_rfc3339_timestamp(modify_date)
-        self.assertEqual(metadata_date, modify_date)
-        # XMP Media Management:
-        # - DocumentID:
-        key, document_id = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.DocumentID')
-        self.assert_uuid_urn(document_id)
-        self.assertNotEqual(document_id, self._original_document_id)
-        # - History:
-        self.assertEqual(pop(), ('Xmp.xmpMM.History', 'type="Seq"'))
-        # - History[1]:
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[1]', 'type="Struct"'))
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:action', 'created'))
-        key, original_instance_id = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.History[1]/stEvt:instanceID')
-        self.assertEqual(original_instance_id, self._original_instance_id)
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:softwareAgent', self._original_software_agent))
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:when', create_date))
-        # - History[2]:
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[2]', 'type="Struct"'))
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[2]/stEvt:action', 'converted'))
-        key, event_instance_id = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.History[2]/stEvt:instanceID')
-        self.assert_uuid_urn(event_instance_id)
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[2]/stEvt:parameters', 'from image/png to image/x-test'))
-        key, software_agent = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.History[2]/stEvt:softwareAgent')
-        self.assert_correct_software_agent(software_agent)
-        self.assertEqual(pop(), ('Xmp.xmpMM.History[2]/stEvt:when', metadata_date))
-        # - InstanceID:
-        key, instance_id = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.InstanceID')
-        self.assert_uuid_urn(instance_id)
-        self.assertEqual(instance_id, event_instance_id)
-        self.assertNotEqual(instance_id, original_instance_id)
-        # - OriginalDocumentID:
-        key, original_document_id = pop()
-        self.assertEqual(key, 'Xmp.xmpMM.OriginalDocumentID')
-        self.assertEqual(original_document_id, self._original_document_id)
-        try:
-            line = pop()
-        except StopIteration:
-            line = None
-        self.assertIsNone(line)
+            # Dublin Core:
+            self.assertEqual(pop(), ('Xmp.dc.format', 'image/x-test'))
+            # Internal properties:
+            self.assertEqual(pop(), ('Xmp.didjvu.test_bool', 'True'))
+            self.assertEqual(pop(), ('Xmp.didjvu.test_int', '42'))
+            self.assertEqual(pop(), ('Xmp.didjvu.test_str', 'eggs'))
+            # TIFF:
+            self.assertEqual(pop(), ('Xmp.tiff.ImageHeight', '42'))
+            self.assertEqual(pop(), ('Xmp.tiff.ImageWidth', '69'))
+            # XMP:
+            key, create_date = pop()
+            self.assertEqual((key, create_date), ('Xmp.xmp.CreateDate', self._original_create_date))
+            self.assertEqual(pop(), ('Xmp.xmp.CreatorTool', self._original_software_agent))
+            key, metadata_date = pop()
+            self.assertEqual(key, 'Xmp.xmp.MetadataDate')
+            self.assert_rfc3339_timestamp(metadata_date)
+            key, modify_date = pop()
+            self.assertEqual(key, 'Xmp.xmp.ModifyDate')
+            self.assert_rfc3339_timestamp(modify_date)
+            self.assertEqual(metadata_date, modify_date)
+            # XMP Media Management:
+            # - DocumentID:
+            key, document_id = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.DocumentID')
+            self.assert_uuid_urn(document_id)
+            self.assertNotEqual(document_id, self._original_document_id)
+            # - History:
+            self.assertEqual(pop(), ('Xmp.xmpMM.History', 'type="Seq"'))
+            # - History[1]:
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[1]', 'type="Struct"'))
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:action', 'created'))
+            key, original_instance_id = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.History[1]/stEvt:instanceID')
+            self.assertEqual(original_instance_id, self._original_instance_id)
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:softwareAgent', self._original_software_agent))
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[1]/stEvt:when', create_date))
+            # - History[2]:
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[2]', 'type="Struct"'))
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[2]/stEvt:action', 'converted'))
+            key, event_instance_id = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.History[2]/stEvt:instanceID')
+            self.assert_uuid_urn(event_instance_id)
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[2]/stEvt:parameters', 'from image/png to image/x-test'))
+            key, software_agent = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.History[2]/stEvt:softwareAgent')
+            self.assert_correct_software_agent(software_agent)
+            self.assertEqual(pop(), ('Xmp.xmpMM.History[2]/stEvt:when', metadata_date))
+            # - InstanceID:
+            key, instance_id = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.InstanceID')
+            self.assert_uuid_urn(instance_id)
+            self.assertEqual(instance_id, event_instance_id)
+            self.assertNotEqual(instance_id, original_instance_id)
+            # - OriginalDocumentID:
+            key, original_document_id = pop()
+            self.assertEqual(key, 'Xmp.xmpMM.OriginalDocumentID')
+            self.assertEqual(original_document_id, self._original_document_id)
+            try:
+                line = pop()
+            except StopIteration:
+                line = None
+            self.assertIsNone(line)
 
     def _test_updated_libxmp(self, xmp_file, exception=None):
         if exception is not None:

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -124,7 +124,6 @@ class MetadataTestCase(UuuidCheckMixin, TestCase):
         except ipc.CalledProcessError:
             if not fail_ok:
                 raise
-        
 
     def assert_correct_software_agent(self, software_agent):
         self.assertRegex(


### PR DESCRIPTION
This resolves the *ResourceWarning*s being produced when running the tests. Fixes #14.

Additionally, *py3exiv2* tests would be skipped in the past due to *Boost.Python* not being found when running the tests. This has been fixed as well.